### PR TITLE
Linter doesn't want the css file

### DIFF
--- a/docs/using-testharness.html
+++ b/docs/using-testharness.html
@@ -43,7 +43,6 @@ a W3C service you should just point to the W3C copy:</p>
 
 <pre><code>  &lt;script src='/resources/testharness.js'&gt;&lt;/script&gt;
   &lt;script src='/resources/testharnessreport.js'&gt;&lt;/script&gt;
-  &lt;link rel='stylesheet' href='/resources/testharness.css'&gt;
 </code></pre>
 
 <p>At which point you might rightfully ask why there are two files. The reason for this is


### PR DESCRIPTION
The linter complains about the CSS file being explicitly present, so we shouldn't include it in the docs - I just copied these lines into my test and then got a linting failure. ;_;